### PR TITLE
This filter needs flushing

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -128,6 +128,10 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
   # The flush interval, when the metrics event is created. Must be a multiple of 5s.
   config :flush_interval, :validate => :number, :default => 5
 
+  # Call the filter flush method at regular interval.
+  # Optional.
+  config :periodic_flush, :validate => :boolean, :default => true
+
   # The clear interval, when all counter are reset.
   #
   # If set to -1, the default value, the metrics will never be cleared.


### PR DESCRIPTION
Rebase of https://github.com/elasticsearch/logstash/pull/1818 to fix metrics filter in 1.5
I left the test out of this PR due to the usage of tempfile, need to think of a better solution

And we must beg @colinsurprenant to resume work on https://github.com/elasticsearch/logstash/issues/1839