### PR TITLE
Use sub-fields instead of dotted notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 3.0.0
+ - Elasticsearch 2.0 does not allow for dots in field names.  This change changes to use sub-field syntax instead of
+ dotted syntax.  This is a breaking change.
+
 ## 2.0.2
  - Fix test that used deprecated "tags" syntax
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/logstash-filter-metrics.gemspec
+++ b/logstash-filter-metrics.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-metrics'
-  s.version         = '2.0.3'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The metrics filter is useful for aggregating metrics."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -26,4 +26,3 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-

--- a/spec/filters/metrics_spec.rb
+++ b/spec/filters/metrics_spec.rb
@@ -6,7 +6,7 @@ describe LogStash::Filters::Metrics do
   context "with basic meter config" do
     context "when no events were received" do
       it "should not flush" do
-        config = {"meter" => ["http.%{response}"]}
+        config = {"meter" => ["http_%{response}"]}
         filter = LogStash::Filters::Metrics.new config
         filter.register
 
@@ -18,7 +18,7 @@ describe LogStash::Filters::Metrics do
     context "when events are received" do
       context "on the first flush" do
         subject {
-          config = {"meter" => ["http.%{response}"]}
+          config = {"meter" => ["http_%{response}"]}
           filter = LogStash::Filters::Metrics.new config
           filter.register
           filter.filter LogStash::Event.new({"response" => 200})
@@ -29,22 +29,24 @@ describe LogStash::Filters::Metrics do
 
         it "should flush counts" do
           insist { subject.length } == 1
-          insist { subject.first["http.200.count"] } == 2
-          insist { subject.first["http.404.count"] } == 1
+          insist { subject.first["http_200"]["count"] } == 2
+          insist { subject.first["http_404"]["count"] } == 1
         end
 
         it "should include rates and percentiles" do
-          metrics = ["http.200.rate_1m", "http.200.rate_5m", "http.200.rate_15m",
-                     "http.404.rate_1m", "http.404.rate_5m", "http.404.rate_15m"]
-          metrics.each do |metric|
-            insist { subject.first }.include? metric
+          meters = [ "http_200", "http_404" ]
+          rates = [ "rate_1m", "rate_5m", "rate_15m" ]
+          meters.each do |meter|
+            rates.each do |rate|
+              insist { subject.first[meter] }.include? rate
+            end
           end
         end
       end
 
       context "on the second flush" do
         it "should not reset counts" do
-          config = {"meter" => ["http.%{response}"]}
+          config = {"meter" => ["http_%{response}"]}
           filter = LogStash::Filters::Metrics.new config
           filter.register
           filter.filter LogStash::Event.new({"response" => 200})
@@ -54,8 +56,8 @@ describe LogStash::Filters::Metrics do
           events = filter.flush
           events = filter.flush
           insist { events.length } == 1
-          insist { events.first["http.200.count"] } == 2
-          insist { events.first["http.404.count"] } == 1
+          insist { events.first["http_200"]["count"] } == 2
+          insist { events.first["http_404"]["count"] } == 1
         end
       end
     end
@@ -64,7 +66,7 @@ describe LogStash::Filters::Metrics do
       context "on the first flush" do
         subject {
           config = {
-            "meter" => ["http.%{response}"],
+            "meter" => ["http_%{response}"],
             "rates" => [1]
           }
           filter = LogStash::Filters::Metrics.new config
@@ -76,9 +78,9 @@ describe LogStash::Filters::Metrics do
         }
 
         it "should include only the requested rates" do
-          rate_fields = subject.first.to_hash.keys.select {|field| field.start_with?("http.200.rate") }
+          rate_fields = subject.first["http_200"].to_hash.keys.select {|field| field.start_with?("rate") }
           insist { rate_fields.length } == 1
-          insist { rate_fields }.include? "http.200.rate_1m"
+          insist { rate_fields }.include? "rate_1m"
         end
       end
     end
@@ -86,8 +88,8 @@ describe LogStash::Filters::Metrics do
 
   context "with multiple instances" do
     it "counts should be independent" do
-      config1 = {"meter" => ["http.%{response}"]}
-      config2 = {"meter" => ["http.%{response}"]}
+      config1 = {"meter" => ["http_%{response}"]}
+      config2 = {"meter" => ["http_%{response}"]}
       filter1 = LogStash::Filters::Metrics.new config1
       filter2 = LogStash::Filters::Metrics.new config2
       events1 = [
@@ -112,17 +114,17 @@ describe LogStash::Filters::Metrics do
       events1 = filter1.flush
       events2 = filter2.flush
 
-      insist { events1.first["http.200.count"] } == 1
-      insist { events2.first["http.200.count"] } == 2
-      insist { events1.first["http.404.count"] } == 1
-      insist { events2.first["http.404.count"] } == nil
+      insist { events1.first["http_200"]["count"] } == 1
+      insist { events2.first["http_200"]["count"] } == 2
+      insist { events1.first["http_404"]["count"] } == 1
+      insist { events2.first["http_404"] } == nil
     end
   end
 
   context "with timer config" do
     context "on the first flush" do
       subject {
-        config = {"timer" => ["http.request_time", "%{request_time}"]}
+        config = {"timer" => ["http_request_time", "%{request_time}"]}
         filter = LogStash::Filters::Metrics.new config
         filter.register
         filter.filter LogStash::Event.new({"request_time" => 10})
@@ -133,34 +135,34 @@ describe LogStash::Filters::Metrics do
 
       it "should flush counts" do
         insist { subject.length } == 1
-        insist { subject.first["http.request_time.count"] } == 3
+        insist { subject.first["http_request_time"]["count"] } == 3
       end
 
       it "should include rates and percentiles keys" do
         metrics = ["rate_1m", "rate_5m", "rate_15m", "p1", "p5", "p10", "p90", "p95", "p99"]
         metrics.each do |metric|
-          insist { subject.first }.include? "http.request_time.#{metric}"
+          insist { subject.first["http_request_time"] }.include? metric
         end
       end
 
       it "should include min value" do
-        insist { subject.first['http.request_time.min'] } == 10.0
+        insist { subject.first['http_request_time']['min'] } == 10.0
       end
 
       it "should include mean value" do
-        insist { subject.first['http.request_time.mean'] } == 20.0
+        insist { subject.first['http_request_time']['mean'] } == 20.0
       end
 
       it "should include stddev value" do
-        insist { subject.first['http.request_time.stddev'] } == Math.sqrt(10.0)
+        insist { subject.first['http_request_time']['stddev'] } == Math.sqrt(10.0)
       end
 
       it "should include max value" do
-        insist { subject.first['http.request_time.max'] } == 30.0
+        insist { subject.first['http_request_time']['max'] } == 30.0
       end
 
       it "should include percentile value" do
-        insist { subject.first['http.request_time.p99'] } == 30.0
+        insist { subject.first['http_request_time']['p99'] } == 30.0
       end
     end
   end
@@ -169,7 +171,7 @@ describe LogStash::Filters::Metrics do
     context "on the first flush" do
       subject {
         config = {
-          "timer" => ["http.request_time", "request_time"],
+          "timer" => ["http_request_time", "request_time"],
           "rates" => [1],
           "percentiles" => [1, 2]
         }
@@ -181,20 +183,20 @@ describe LogStash::Filters::Metrics do
 
       it "should flush counts" do
         insist { subject.length } == 1
-        insist { subject.first["http.request_time.count"] } == 1
+        insist { subject.first["http_request_time"]["count"] } == 1
       end
 
       it "should include only the requested rates" do
-        rate_fields = subject.first.to_hash.keys.select {|field| field.start_with?("http.request_time.rate") }
+        rate_fields = subject.first["http_request_time"].to_hash.keys.select {|field| field.start_with?("rate") }
         insist { rate_fields.length } == 1
-        insist { rate_fields }.include? "http.request_time.rate_1m"
+        insist { rate_fields }.include? "rate_1m"
       end
 
       it "should include only the requested percentiles" do
-        percentile_fields = subject.first.to_hash.keys.select {|field| field.start_with?("http.request_time.p") }
+        percentile_fields = subject.first["http_request_time"].to_hash.keys.select {|field| field.start_with?("p") }
         insist { percentile_fields.length } == 2
-        insist { percentile_fields }.include? "http.request_time.p1"
-        insist { percentile_fields }.include? "http.request_time.p2"
+        insist { percentile_fields }.include? "p1"
+        insist { percentile_fields }.include? "p2"
       end
     end
   end
@@ -202,7 +204,7 @@ describe LogStash::Filters::Metrics do
 
   context "when a custom flush_interval is set" do
     it "should flush only when required" do
-      config = {"meter" => ["http.%{response}"], "flush_interval" => 15}
+      config = {"meter" => ["http_%{response}"], "flush_interval" => 15}
       filter = LogStash::Filters::Metrics.new config
       filter.register
       filter.filter LogStash::Event.new({"response" => 200})
@@ -218,21 +220,21 @@ describe LogStash::Filters::Metrics do
 
   context "when a custom clear_interval is set" do
     it "should clear the metrics after interval has passed" do
-      config = {"meter" => ["http.%{response}"], "clear_interval" => 15}
+      config = {"meter" => ["http_%{response}"], "clear_interval" => 15}
       filter = LogStash::Filters::Metrics.new config
       filter.register
       filter.filter LogStash::Event.new({"response" => 200})
 
-      insist { filter.flush.first["http.200.count"] } == 1 # 5s
-      insist { filter.flush.first["http.200.count"] } == 1 # 10s
-      insist { filter.flush.first["http.200.count"] } == 1 # 15s
+      insist { filter.flush.first["http_200"]["count"] } == 1 # 5s
+      insist { filter.flush.first["http_200"]["count"] } == 1 # 10s
+      insist { filter.flush.first["http_200"]["count"] } == 1 # 15s
       insist { filter.flush }.nil?                         # 20s
     end
   end
 
   context "when invalid rates are set" do
     subject {
-      config = {"meter" => ["http.%{response}"], "rates" => [90]}
+      config = {"meter" => ["http_%{response}"], "rates" => [90]}
       filter = LogStash::Filters::Metrics.new config
     }
 


### PR DESCRIPTION
Prior implementations of the metrics filter plugin used dotted field
names.  Elasticsearch does not allow field names to have dots, beginning
with version 2.0.

This PR changes the plugin behavior to be friendly with Elasticsearch 2.0
again by using sub-fields and removes examples with dots.

fixes #19