### PR TITLE
Clean up and clarify documentation

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -10,7 +10,7 @@ require "logstash/namespace"
 # dotted notation to avoid colliding with versions of Elasticsearch 2.0+.  Please
 # note the changes in the documentation (underscores and sub-fields used).
 #
-# For example, if you have a field 'response' that is
+# For example, if you have a field `response` that is
 # a http response code, and you want to count each
 # kind of response, you can do this:
 # [source,ruby]
@@ -22,7 +22,7 @@ require "logstash/namespace"
 #     }
 #
 # Metrics are flushed every 5 seconds by default or according to
-# 'flush_interval'. Metrics appear as
+# `flush_interval`. Metrics appear as
 # new events in the event stream and go through any filters
 # that occur after as well as outputs.
 #
@@ -32,30 +32,33 @@ require "logstash/namespace"
 # The event that is flushed will include every 'meter' and 'timer'
 # metric in the following way:
 #
-# #### 'meter' values
+# ==== 'meter' values
 #
 # For a `meter => "something"` you will receive the following fields:
 #
 # * "[thing][count]" - the total count of events
-# * "[thing][rate_1m]" - the 1-minute rate (sliding)
-# * "[thing][rate_5m]" - the 5-minute rate (sliding)
-# * "[thing][rate_15m]" - the 15-minute rate (sliding)
+# * "[thing][rate_1m]" - the per-second event rate in a 1-minute sliding window
+# * "[thing][rate_5m]" - the per-second event rate in a 5-minute sliding window
+# * "[thing][rate_15m]" - the per-second event rate in a 15-minute sliding window
 #
-# #### 'timer' values
+# ==== 'timer' values
 #
 # For a `timer => [ "thing", "%{duration}" ]` you will receive the following fields:
 #
 # * "[thing][count]" - the total count of events
-# * "[thing][rate_1m]" - the 1-minute rate of events (sliding)
-# * "[thing][rate_5m]" - the 5-minute rate of events (sliding)
-# * "[thing][rate_15m]" - the 15-minute rate of events (sliding)
+# * "[thing][rate_1m]" - the per-second event rate in a 1-minute sliding window
+# * "[thing][rate_5m]" - the per-second event rate in a 5-minute sliding window
+# * "[thing][rate_15m]" - the per-second event rate in a 15-minute sliding window
 # * "[thing][min]" - the minimum value seen for this metric
 # * "[thing][max]" - the maximum value seen for this metric
 # * "[thing][stddev]" - the standard deviation for this metric
 # * "[thing][mean]" - the mean for this metric
 # * "[thing][pXX]" - the XXth percentile for this metric (see `percentiles`)
 #
-# #### Example: computing event rate
+# The default lengths of the event rate window (1, 5, and 15 minutes)
+# can be configured with the `rates` option.
+#
+# ==== Example: Computing event rate
 #
 # For a simple example, let's track how many events per second are running
 # through logstash:
@@ -96,7 +99,7 @@ require "logstash/namespace"
 #     rate: 25875.892745934525
 #     rate: 26836.42375967113
 #
-# We see the output includes our 'events' 1-minute rate.
+# We see the output includes our events' 1-minute rate.
 #
 # In the real world, you would emit this to graphite or another metrics store,
 # like so:
@@ -115,12 +118,12 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
   # syntax: `timer => [ "name of metric", "%{time_value}" ]`
   config :timer, :validate => :hash, :default => {}
 
-  # Don't track events that have @timestamp older than some number of seconds.
+  # Don't track events that have `@timestamp` older than some number of seconds.
   #
   # This is useful if you want to only include events that are near real-time
   # in your metrics.
   #
-  # Example, to only count events that are within 10 seconds of real-time, you
+  # For example, to only count events that are within 10 seconds of real-time, you
   # would do this:
   #
   #     filter {
@@ -144,7 +147,7 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
   # Possible values are 1, 5, and 15.
   config :rates, :validate => :array, :default => [1, 5, 15]
 
-  # The percentiles that should be measured
+  # The percentiles that should be measured and emitted for timer values.
   config :percentiles, :validate => :array, :default => [1, 5, 10, 90, 95, 99, 100]
 
   def register


### PR DESCRIPTION
Several people have been confused about the unit of the rate, so make it clear that it's a per-second rate. Also fix various formatting issues to bring this plugin in line with with others. This addresses parts of the confusion in #29.