### PR TITLE
add array of meters and timers included

### DIFF
--- a/lib/logstash/filters/metrics.rb
+++ b/lib/logstash/filters/metrics.rb
@@ -194,11 +194,13 @@ class LogStash::Filters::Metrics < LogStash::Filters::Base
 
     event = LogStash::Event.new
     event.set("message", Socket.gethostname)
+    event.set("meters", @metric_meters.keys)
     @metric_meters.each_pair do |name, metric|
       flush_rates event, name, metric
       metric.clear if should_clear?
     end
 
+    event.set("timers", @metric_timers.keys)
     @metric_timers.each_pair do |name, metric|
       flush_rates event, name, metric
       # These 4 values are not sliding, so they probably are not useful.


### PR DESCRIPTION
This is a workaround for #30 that is fully backward compatible.  It allows you to split the metrics event and then assign the values to a known key using:

```
if "metric" in [tags] {
    split {
      field => "meters"
    }

    ruby {
      code => "event['meter'] = event[event['meters']]"
    }
  }
```

Thoughts?

This would potentially be superseded by #41.
