### PR TITLE
bump to 4.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.6
+  - Fixed two minor typos in documentation
+
 ## 4.0.5
   - Update gemspec summary
 

--- a/logstash-filter-metrics.gemspec
+++ b/logstash-filter-metrics.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-metrics'
-  s.version         = '4.0.5'
+  s.version         = '4.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Aggregates metrics"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
```
% git lg v4.0.5..
* 3a39f46 - (origin/master, master) [skip ci] Travis: update LOGSTASH_BRANCH from 6.[0..4] to 6.5 (4 weeks ago) <Rob Bavey>
* b3401db - pin bundler version to < 2 (5 weeks ago) <Rob Bavey>
* 0ad50cd - Update index.asciidoc (4 months ago) <horacimacias>
* 07bdc81 - [skip ci] update license to 2018 (1 year, 1 month ago) <Joao Duarte>
* 34b5c31 - Minor typo fix (1 year, 1 month ago) <Scott Brenner>
```