### PR TITLE
[DOC] Recommendation when using a lot of metrics filters

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -75,6 +75,9 @@ For a `timer => { "thing" => "%{duration}" }` you will receive the following fie
 The default lengths of the event rate window (1, 5, and 15 minutes)
 can be configured with the `rates` option.
 
+IMPORTANT: When using several `metrics` filters (in particular the `timer`), it might
+become necessary to increase the `Xss` setting in `jvm.options` to avoid `StackOverflowException`.
+
 ==== Example: Computing event rate
 
 For a simple example, let's track how many events per second are running


### PR DESCRIPTION
Following a report from a user, we discovered it might be necessary to increase `Xss` in `jvm.options`.

The (third party) `Metriks::ExponentiallyDecayingSample` uses a red-black tree to ensure the worst-case cost to look up an individual entry is `O(log N)`. It keeps a maximum of 1024 entries around, which means that the worst-case lookup is 10 steps.
